### PR TITLE
使用 tinytex::tlmgr_install() 安装包

### DIFF
--- a/.github/workflows/Render-Book.yaml
+++ b/.github/workflows/Render-Book.yaml
@@ -40,7 +40,7 @@ jobs:
           export PATH=$HOME/bin:$PATH
           curl -fsSL https://www.preining.info/rsa.asc | tlmgr key add -
           tlmgr update --self --all --no-auto-install --repository=${{ env.CTAN_URL }}/systems/texlive/tlnet/
-          tlmgr install $(cat texlive.txt | tr '\n' ' ') || true
+          Rscript -e 'tinytex::tlmgr_install(readLines("texlive.txt"))'
           sudo apt-get install -y fonts-dejavu
           fc-list | grep 'dejavu' | sort
 


### PR DESCRIPTION
对于包含可执行程序的包，安装之后需要运行 `tlmgr path add` 以添加符号链接到 PATH 路径中（这里是 `~/bin`）